### PR TITLE
implemented news link preview and some minor fixes to help avoid out …of memory error due to loading so many images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,4 +59,8 @@ dependencies {
 
     implementation "androidx.paging:paging-runtime:3.0.0-alpha01"
 
+    implementation "org.jsoup:jsoup:1.11.3"
+    implementation "io.github.ponnamkarthik:richlinkpreview:1.0.9"
+    implementation "com.squareup.picasso:picasso:2.71828"
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:largeHeap="true"
         android:usesCleartextTraffic="false">
         <activity
             android:name=".activity.DetailsActivity"

--- a/app/src/main/java/io/saytheirnames/activity/DetailsActivity.java
+++ b/app/src/main/java/io/saytheirnames/activity/DetailsActivity.java
@@ -1,5 +1,7 @@
 package io.saytheirnames.activity;
 
+import android.annotation.SuppressLint;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -28,6 +30,7 @@ import io.saytheirnames.utils.ShareUtil;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.snackbar.Snackbar;
+import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -93,6 +96,25 @@ public class DetailsActivity extends AppCompatActivity
         renderMedia();
         renderSocialMedia();
         renderData();
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        //clear Glide's disk cache whenever an activity is destroyed. Mechanism for helping against memory leaks/ Out of memory errors
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                // This method must be called on a background thread.
+                Glide.get(getApplicationContext()).clearDiskCache();
+
+                // DetailsActivity's richLinkViewer  (in the NewsAdapter) internally uses Picasso
+                Picasso.get().shutdown();
+                return null;
+            }
+        };
     }
 
     private void initializeBackend() {
@@ -187,14 +209,13 @@ public class DetailsActivity extends AppCompatActivity
             newsGroup.setVisibility(View.GONE);
         }
 
-        //TODO: Add Media adapter
         if (person.getMedia() != null && person.getMedia().size() > 0) {
             mediaList.clear();
             mediaList.addAll(person.getMedia());
             mediaAdapter.notifyDataSetChanged();
             mediaGroup.setVisibility(View.VISIBLE);
         } else {
-            newsGroup.setVisibility(View.GONE);
+            mediaGroup.setVisibility(View.GONE);
         }
 
         if (person.getHashtags() != null && person.getHashtags().size() > 0) {

--- a/app/src/main/java/io/saytheirnames/activity/DonationDetailsActivity.java
+++ b/app/src/main/java/io/saytheirnames/activity/DonationDetailsActivity.java
@@ -25,6 +25,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.snackbar.Snackbar;
 import com.jgabrielfreitas.core.BlurImageView;
+import com.squareup.picasso.Picasso;
 
 import jp.wasabeef.glide.transformations.BlurTransformation;
 import retrofit2.Call;
@@ -61,6 +62,22 @@ public class DonationDetailsActivity extends AppCompatActivity implements View.O
         identifier = intent.getStringExtra(EXTRA_ID);
 
        loadData();
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        //clear Glide's disk cache whenever an activity is destroyed. Mechanism for helping against memory leaks/ Out of memory errors
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                // This method must be called on a background thread.
+                Glide.get(getApplicationContext()).clearDiskCache();
+                return null;
+            }
+        };
     }
 
     void initView() {

--- a/app/src/main/java/io/saytheirnames/activity/MainActivity.java
+++ b/app/src/main/java/io/saytheirnames/activity/MainActivity.java
@@ -1,5 +1,7 @@
 package io.saytheirnames.activity;
 
+import android.annotation.SuppressLint;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.MenuItem;
 
@@ -15,7 +17,9 @@ import io.saytheirnames.fragments.HomeFragment;
 import io.saytheirnames.fragments.PetitionsFragment;
 import io.saytheirnames.network.BackendInterface;
 
+import com.bumptech.glide.Glide;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.squareup.picasso.Picasso;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -70,6 +74,36 @@ public class MainActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
     }
 
+    @Override
+    public void onBackPressed() {
+        MenuItem homeItem = mBottomNav.getMenu().getItem(0);
+        if (mSelectedItem != homeItem.getItemId()) {
+            // select home item
+            selectFragment(homeItem);
+
+            //this will also highlight the home menu item icon
+            updateBottomNavBasedOnTag(HOME_TAG);
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        //clear Glide's disk cache whenever an activity is destroyed. Mechanism for helping against memory leaks/ Out of memory errors
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                // This method must be called on a background thread.
+                Glide.get(getApplicationContext()).clearDiskCache();
+                return null;
+            }
+        };
+    }
+
     private void setDefaultFragment() {
         mBottomNav.setSelectedItemId(R.id.navigation_home);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
@@ -97,17 +131,6 @@ public class MainActivity extends AppCompatActivity {
                 break;
         }
         mBottomNav.setSelectedItemId(mSelectedItem);
-    }
-
-    @Override
-    public void onBackPressed() {
-        MenuItem homeItem = mBottomNav.getMenu().getItem(0);
-        if (mSelectedItem != homeItem.getItemId()) {
-            // select home item
-            selectFragment(homeItem);
-        } else {
-            super.onBackPressed();
-        }
     }
 
     private void selectFragment(MenuItem item) {

--- a/app/src/main/java/io/saytheirnames/activity/PetitionDetailsActivity.java
+++ b/app/src/main/java/io/saytheirnames/activity/PetitionDetailsActivity.java
@@ -23,6 +23,7 @@ import io.saytheirnames.utils.ShareUtil;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.jgabrielfreitas.core.BlurImageView;
+import com.squareup.picasso.Picasso;
 
 import jp.wasabeef.glide.transformations.BlurTransformation;
 import retrofit2.Call;
@@ -84,6 +85,22 @@ public class PetitionDetailsActivity extends AppCompatActivity implements View.O
         btnSignThisPetition.setOnClickListener(this);
 
         loadData();
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        //clear Glide's disk cache whenever an activity is destroyed. Mechanism for helping against memory leaks/ Out of memory errors
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                // This method must be called on a background thread.
+                Glide.get(getApplicationContext()).clearDiskCache();
+                return null;
+            }
+        };
     }
 
     private void loadData() {

--- a/app/src/main/java/io/saytheirnames/adapters/MediaAdapter.java
+++ b/app/src/main/java/io/saytheirnames/adapters/MediaAdapter.java
@@ -18,7 +18,7 @@ import com.bumptech.glide.request.RequestOptions;
 
 import java.util.List;
 
-public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.NewsViewHolder> {
+public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHolder> {
 
     private MediaListener listener;
     private List<Media> mediaList;
@@ -32,14 +32,13 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.NewsViewHold
 
     @NonNull
     @Override
-    public NewsViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View convertView = LayoutInflater.from(parent.getContext()).inflate(R.layout.news_item, parent, false);
-        return new NewsViewHolder(convertView);
+    public MediaViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View convertView = LayoutInflater.from(parent.getContext()).inflate(R.layout.media_item, parent, false);
+        return new MediaViewHolder(convertView);
     }
 
     @Override
-    public void onBindViewHolder(@NonNull NewsViewHolder holder, final int position) {
-        //TODO: This should support URL previews at some point. I believe there are libraries out there that can do that for us.
+    public void onBindViewHolder(@NonNull MediaViewHolder holder, final int position) {
 
         Media media = mediaList.get(position);
 
@@ -48,7 +47,7 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.NewsViewHold
                 .apply(new RequestOptions()
                         .placeholder(R.drawable.blm2)
                         .error(R.drawable.blm2))
-                .into(holder.newsUrl);
+                .into(holder.mediaImage);
 
         holder.itemView.setOnClickListener(v -> listener.onMediaSelected(media));
 
@@ -70,13 +69,13 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.NewsViewHold
         void onMediaSelected(Media media);
     }
 
-    static class NewsViewHolder extends RecyclerView.ViewHolder {
-        ImageView newsUrl;
+    static class MediaViewHolder extends RecyclerView.ViewHolder {
+        ImageView mediaImage;
         CardView cardView;
 
-        public NewsViewHolder(@NonNull View itemView) {
+        public MediaViewHolder(@NonNull View itemView) {
             super(itemView);
-            newsUrl = itemView.findViewById(R.id.news);
+            mediaImage = itemView.findViewById(R.id.image);
             cardView = itemView.findViewById(R.id.cardView);
         }
     }

--- a/app/src/main/java/io/saytheirnames/adapters/NewsAdapter.java
+++ b/app/src/main/java/io/saytheirnames/adapters/NewsAdapter.java
@@ -10,10 +10,11 @@ import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 
+import io.github.ponnamkarthik.richlinkpreview.RichLinkViewSkype;
+
+import io.github.ponnamkarthik.richlinkpreview.ViewListener;
 import io.saytheirnames.R;
 import io.saytheirnames.models.News;
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.request.RequestOptions;
 
 import java.util.List;
 
@@ -38,19 +39,21 @@ public class NewsAdapter extends RecyclerView.Adapter<NewsAdapter.NewsViewHolder
 
     @Override
     public void onBindViewHolder(@NonNull NewsViewHolder holder, final int position) {
-        //TODO: This should support URL previews at some point. I believe there are libraries out there that can do that for us.
 
+        //TODO: figure out how to handle cases where the holder's richLinkView could not fetch the preview from the url
+        //right now, it just shows a blank shape, but the link still works
         News news = newsList.get(position);
+        holder.richLinkView.setLink(news.getUrl(), new ViewListener() {
+            @Override
+            public void onSuccess(boolean status) {
+            }
+            @Override
+            public void onError(Exception e) {
+            }
+        });
 
-        Glide.with(holder.itemView.getContext())
-                .load(news.getUrl())
-                .apply(new RequestOptions()
-                        .placeholder(R.drawable.blm2)
-                        .error(R.drawable.blm2))
-                .into(holder.newsUrl);
-
+        //hyperlinking still works even if the preview wasnt fetched successfully
         holder.itemView.setOnClickListener(v -> listener.onNewsSelected(news));
-
 
         Log.d("IASD:::", String.valueOf(newsList.size()));
     }
@@ -70,13 +73,13 @@ public class NewsAdapter extends RecyclerView.Adapter<NewsAdapter.NewsViewHolder
     }
 
     static class NewsViewHolder extends RecyclerView.ViewHolder {
-        ImageView newsUrl;
         CardView cardView;
+        RichLinkViewSkype richLinkView;
 
         public NewsViewHolder(@NonNull View itemView) {
             super(itemView);
-            newsUrl = itemView.findViewById(R.id.news);;
             cardView = itemView.findViewById(R.id.cardView);
+            richLinkView = itemView.findViewById(R.id.richLinkViewForNews);
         }
     }
 }

--- a/app/src/main/res/layout/media_item.xml
+++ b/app/src/main/res/layout/media_item.xml
@@ -15,12 +15,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <io.github.ponnamkarthik.richlinkpreview.RichLinkViewSkype
-            android:id="@+id/richLinkViewForNews"
+        <ImageView
+            android:id="@+id/image"
             android:layout_width="200dp"
-            android:layout_height="wrap_content"
+            android:layout_height="200dp"
             android:scaleType="centerCrop"
-            android:gravity="center"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
In this branch, before working, I first pulled from development and ran the app. I discovered that upon navigating between the different pages and scrolling (hence, loading) so many images, the app would crash due to out of memory error. I also spotted a TODO to implement link previewing. I decided to work on these two things. For the memory leak/out of memory error stuff, I simply did some minor optimizations, like using a large heap (see manifest file), as well as clearing glide disk cache when an activity is destroyed. For the news link preview, I used a library called richLinkview to implement it. Also refactored out the media adapter to use a media_item fragment!